### PR TITLE
Fix build issue in grpc.kafka.fanout/grpc.reliable.streaming

### DIFF
--- a/grpc.kafka.fanout/grpc.reliable.streaming/pom.xml
+++ b/grpc.kafka.fanout/grpc.reliable.streaming/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.54.1</grpc.version>
         <protobuf.version>3.21.7</protobuf.version>
-        <protoc.version>3.21.7</protoc.version>
+        <protoc.version>3.24.4</protoc.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -83,15 +83,10 @@
             <version>2.9.0</version> <!-- prevent downgrade via protobuf-java-util -->
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version> <!-- prevent downgrade of version in protobuf-java-util -->
-        </dependency>
-        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>annotations-api</artifactId>
             <version>6.0.53</version>
-            <scope>provided</scope> <!-- not needed at runtime -->
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fix maven build issue related to dependency version clash.

Fixes: #83 