### PR TITLE
Add websocket support to the mqtt broker example

### DIFF
--- a/amqp.reflect/zilla.yaml
+++ b/amqp.reflect/zilla.yaml
@@ -14,7 +14,7 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7172
         - 7171
     routes:

--- a/http.echo.jwt/README.md
+++ b/http.echo.jwt/README.md
@@ -86,7 +86,7 @@ The request is rejected as expected, and without leaking any information about f
 ```
 < HTTP/1.1 404 Not Found
 < Connection: close
-< 
+<
 ```
 
 Create a token with the `echo:stream` scope.

--- a/http.echo.jwt/zilla.yaml
+++ b/http.echo.jwt/zilla.yaml
@@ -26,11 +26,11 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7114
         - 7143
     routes:
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
         - when:

--- a/http.filesystem.config.server/zilla-config/zilla.yaml
+++ b/http.filesystem.config.server/zilla-config/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7144
         - 7115
     routes:
         - when:
             - port: 7144
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7115
           exit: north_http_server
   north_tls_server:

--- a/http.filesystem/zilla.yaml
+++ b/http.filesystem/zilla.yaml
@@ -14,11 +14,11 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7114
         - 7143
     routes:
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
         - when:

--- a/http.kafka.async/README.md
+++ b/http.kafka.async/README.md
@@ -194,7 +194,7 @@ The previous asynchronous request will complete with `200 OK` if done within `60
 < HTTP/1.1 202 Accepted
 < Content-Length: 0
 < Location: /items/5cf7a1d5-3772-49ef-86e7-ba6f2c7d7d07;1-e75a4e507cc0dc66a28f5a9617392fe8
-< 
+<
 * Connection #0 to host localhost left intact
 ```
 

--- a/http.kafka.async/zilla.yaml
+++ b/http.kafka.async/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/http.kafka.cache/zilla.yaml
+++ b/http.kafka.cache/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/http.kafka.crud/zilla.yaml
+++ b/http.kafka.crud/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/http.kafka.oneway/zilla.yaml
+++ b/http.kafka.oneway/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/http.kafka.sasl.scram/zilla.yaml
+++ b/http.kafka.sasl.scram/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/http.kafka.sync/README.md
+++ b/http.kafka.sync/README.md
@@ -154,9 +154,9 @@ The previous `PUT` request will complete.
 ```text
 < HTTP/1.1 200 OK
 < Content-Length: 56
-< 
+<
 * Connection #0 to host localhost left intact
-{"greeting":"Hello, world Thu Oct 26 13:18:18 EDT 2023"}%  
+{"greeting":"Hello, world Thu Oct 26 13:18:18 EDT 2023"}% 
 ```
 
 Verify the response via the kafka `items-responses` topic.

--- a/http.kafka.sync/zilla.yaml
+++ b/http.kafka.sync/zilla.yaml
@@ -26,14 +26,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
     telemetry:

--- a/http.redpanda.sasl.scram/zilla.yaml
+++ b/http.redpanda.sasl.scram/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/mqtt.kafka.broker.jwt/zilla.yaml
+++ b/mqtt.kafka.broker.jwt/zilla.yaml
@@ -26,11 +26,11 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7183
         - 7883
     routes:
-        - when: 
+        - when:
             - port: 7183
           exit: north_mqtt_server
         - when:

--- a/mqtt.kafka.broker/docker/compose/docker-compose.yaml
+++ b/mqtt.kafka.broker/docker/compose/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     pull_policy: always
     restart: unless-stopped
     ports:
+      - 7114:7114
+      - 7143:7143
       - 7183:7183
       - 7883:7883
     environment:

--- a/mqtt.kafka.broker/docker/compose/setup.sh
+++ b/mqtt.kafka.broker/docker/compose/setup.sh
@@ -18,6 +18,7 @@ if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
   echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
   /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions
   /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
   /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
   "
 

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -22,6 +22,7 @@ kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm
 echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
 /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions
 /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages --config cleanup.policy=compact
+/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
 /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
 "
 kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -10,10 +10,10 @@ fi
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 NAMESPACE=zilla-mqtt-kafka-broker
 ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-echo "Installing $ZILLA_CHART to $NAMESPACE"
+echo "Installing $ZILLA_CHART to $NAMESPACE with Kafka at $KAFKA_HOST:$KAFKA_PORT"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
-    --set extraEnv[1].value="$KAFKA_HOST",extraEnv[2].value="$KAFKA_PORT" \
+    --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
     --set-file zilla\\.yaml=../../zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=../../tls/localhost.p12
 

--- a/mqtt.kafka.broker/k8s/helm/values.yaml
+++ b/mqtt.kafka.broker/k8s/helm/values.yaml
@@ -13,6 +13,10 @@ readinessProbePort: 7183
 
 service:
   ports:
+    - port: 7114
+      name: http
+    - port: 7143
+      name: https
     - port: 7183
       name: mqtt
     - port: 7883

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -1,31 +1,30 @@
 ---
 name: zilla-mqtt-kafka-broker
 bindings:
-
-# Proxy service entrypoint
+  # Proxy service entrypoint
   north_tcp_server:
     type: tcp
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7114
         - 7143
         - 7183
         - 7883
     routes:
-        - when: 
-            - port: 7114
-          exit: north_ws_http_server
-        - when: 
-            - port: 7143
-          exit: north_wss_tls_server
-        - when: 
-            - port: 7183
-          exit: north_mqtt_server
-        - when:
-            - port: 7883
-          exit: north_mqtts_tls_server
+      - when:
+          - port: 7114
+        exit: north_ws_http_server
+      - when:
+          - port: 7143
+        exit: north_wss_tls_server
+      - when:
+          - port: 7183
+        exit: north_mqtt_server
+      - when:
+          - port: 7883
+        exit: north_mqtts_tls_server
 
   # TLS decrypting
   north_mqtts_tls_server:
@@ -76,7 +75,7 @@ bindings:
     kind: server
     exit: north_mqtt_kafka_mapping
 
-# MQTT messages to Kafka topics
+  # MQTT messages to Kafka topics
   north_mqtt_kafka_mapping:
     type: mqtt-kafka
     kind: proxy
@@ -88,7 +87,7 @@ bindings:
         retained: mqtt-retained
     exit: north_kafka_cache_client
 
-# Kafka sync layer
+  # Kafka sync layer
   north_kafka_cache_client:
     type: kafka
     kind: cache_client
@@ -100,9 +99,10 @@ bindings:
       bootstrap:
         - mqtt-messages
         - mqtt-retained
+        - mqtt-places
     exit: south_kafka_client
 
-# Connect to Kafka
+  # Connect to Kafka
   south_kafka_client:
     type: kafka
     kind: client

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -15,7 +15,7 @@ bindings:
     routes:
       - when:
           - port: 7114
-        exit: north_ws_http_server
+        exit: north_http_server
       - when:
           - port: 7143
         exit: north_wss_tls_server
@@ -46,10 +46,10 @@ bindings:
         - localhost
       sni:
         - localhost
-    exit: north_ws_http_server
+    exit: north_http_server
 
   # WebSocket server
-  north_ws_http_server:
+  north_http_server:
     type: http
     kind: server
     routes:
@@ -57,9 +57,11 @@ bindings:
           - headers:
               :scheme: http
               :authority: localhost:7114
+              upgrade: websocket
           - headers:
               :scheme: https
               :authority: localhost:7143
+              upgrade: websocket
         exit: north_ws_server
   north_ws_server:
     type: ws

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -85,6 +85,19 @@ bindings:
         sessions: mqtt-sessions
         messages: mqtt-messages
         retained: mqtt-retained
+    clients:
+      - place/{identity}/#
+    routes:
+      - when:
+          - publish:
+              - topic: place/+/device/#
+              - topic: device/#
+          - subscribe:
+              - topic: place/+/device/#
+              - topic: device/#
+        with:
+          messages: mqtt-devices
+        exit: north_kafka_cache_client
     exit: north_kafka_cache_client
 
   # Kafka sync layer

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -112,7 +112,7 @@ bindings:
       bootstrap:
         - mqtt-messages
         - mqtt-retained
-        - mqtt-places
+        - mqtt-devices
     exit: south_kafka_client
 
   # Connect to Kafka

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -9,16 +9,26 @@ bindings:
     options:
       host: 0.0.0.0
       port: 
+        - 7114
+        - 7143
         - 7183
         - 7883
     routes:
+        - when: 
+            - port: 7114
+          exit: north_ws_http_server
+        - when: 
+            - port: 7143
+          exit: north_wss_tls_server
         - when: 
             - port: 7183
           exit: north_mqtt_server
         - when:
             - port: 7883
-          exit: north_tls_server
-  north_tls_server:
+          exit: north_mqtts_tls_server
+
+  # TLS decrypting
+  north_mqtts_tls_server:
     type: tls
     kind: server
     vault: my_servers
@@ -28,6 +38,39 @@ bindings:
       sni:
         - localhost
     exit: north_mqtt_server
+  north_wss_tls_server:
+    type: tls
+    kind: server
+    vault: my_servers
+    options:
+      keys:
+        - localhost
+      sni:
+        - localhost
+    exit: north_ws_http_server
+
+  # WebSocket server
+  north_ws_http_server:
+    type: http
+    kind: server
+    routes:
+      - when:
+          - headers:
+              :scheme: http
+              :authority: localhost:7114
+          - headers:
+              :scheme: https
+              :authority: localhost:7143
+        exit: north_ws_server
+  north_ws_server:
+    type: ws
+    kind: server
+    routes:
+      - when:
+          - protocol: mqtt
+        exit: north_mqtt_server
+
+  # Shared MQTT server
   north_mqtt_server:
     type: mqtt
     kind: server

--- a/mqtt.proxy.asyncapi/README.md
+++ b/mqtt.proxy.asyncapi/README.md
@@ -32,7 +32,7 @@ The `setup.sh` script:
 - starts port forwarding
 
 ```bash
-./setup.sh 
+./setup.sh
 ```
 
 ```text

--- a/quickstart/zilla.yaml
+++ b/quickstart/zilla.yaml
@@ -7,18 +7,18 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7114
         - 7151
         - 7183
     routes:
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
-        - when: 
+        - when:
             - port: 7151
           exit: north_grpc_http_server
-        - when: 
+        - when:
             - port: 7183
           exit: north_mqtt_server
     telemetry:

--- a/sse.kafka.fanout/zilla.yaml
+++ b/sse.kafka.fanout/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/ws.echo/zilla.yaml
+++ b/ws.echo/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/ws.echo/zilla.yaml
+++ b/ws.echo/zilla.yaml
@@ -42,9 +42,11 @@ bindings:
           - headers:
               :scheme: http
               :authority: localhost:7114
+              upgrade: websocket
           - headers:
               :scheme: https
               :authority: localhost:7143
+              upgrade: websocket
         exit: north_ws_server
   north_ws_server:
     type: ws

--- a/ws.reflect/zilla.yaml
+++ b/ws.reflect/zilla.yaml
@@ -14,14 +14,14 @@ bindings:
     kind: server
     options:
       host: 0.0.0.0
-      port: 
+      port:
         - 7143
         - 7114
     routes:
         - when:
             - port: 7143
           exit: north_tls_server
-        - when: 
+        - when:
             - port: 7114
           exit: north_http_server
   north_tls_server:

--- a/ws.reflect/zilla.yaml
+++ b/ws.reflect/zilla.yaml
@@ -42,9 +42,11 @@ bindings:
           - headers:
               :scheme: http
               :authority: localhost:7114
+              upgrade: websocket
           - headers:
               :scheme: https
               :authority: localhost:7143
+              upgrade: websocket
         exit: north_ws_server
   north_ws_server:
     type: ws


### PR DESCRIPTION
- Add Websocket support for the mqtt.broker.kafka example
- Add routing to the mqtt.broker.kafka example
- formatting and whitespace cleanup

fixes #95