### PR TITLE
Fix kafka broker hostname in kubernetes

### DIFF
--- a/kafka.broker/README.md
+++ b/kafka.broker/README.md
@@ -18,8 +18,17 @@ This resource can be run using Docker compose or Kubernetes. The setup scripts a
 
 If you are running this alongside another example you will want to expose these environment variables
 
+Docker:
+
 ```bash
 export KAFKA_HOST=host.docker.internal
+export KAFKA_PORT=29092
+```
+
+Kubernetes:
+
+```bash
+export KAFKA_HOST=localhost
 export KAFKA_PORT=29092
 ```
 

--- a/kafka.broker/README.md
+++ b/kafka.broker/README.md
@@ -18,17 +18,8 @@ This resource can be run using Docker compose or Kubernetes. The setup scripts a
 
 If you are running this alongside another example you will want to expose these environment variables
 
-Docker:
-
 ```bash
 export KAFKA_HOST=host.docker.internal
-export KAFKA_PORT=29092
-```
-
-Kubernetes:
-
-```bash
-export KAFKA_HOST=localhost
 export KAFKA_PORT=29092
 ```
 

--- a/kafka.broker/k8s/helm/kafka-ui-values.yaml
+++ b/kafka.broker/k8s/helm/kafka-ui-values.yaml
@@ -4,7 +4,7 @@ yamlApplicationConfig:
   kafka:
     clusters:
       - name: local
-        bootstrapServers: host.docker.internal:29092
+        bootstrapServers: kafka:29092
   auth:
     type: disabled
   management:

--- a/kafka.broker/k8s/helm/templates/service-kafka.yaml
+++ b/kafka.broker/k8s/helm/templates/service-kafka.yaml
@@ -39,7 +39,7 @@ spec:
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INTERNAL"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "CLIENT://host.docker.internal:9092,INTERNAL://host.docker.internal:29092"
+              value: "CLIENT://kafka:9092,INTERNAL://kafka:29092"
           ports:
             - containerPort: 9092
             - containerPort: 29092


### PR DESCRIPTION
Fix kafka broker hostname in kubernetes in the `kafka.broker` example.