### PR TITLE
Improve example variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wget -qO- https://raw.githubusercontent.com/aklivity/zilla-examples/main/startup
 ```
 
 ```text
-Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-bootstrap][--redpanda] example.name
+Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-kafka-init][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
@@ -55,7 +55,7 @@ Options:
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
     -v | --zilla-version  Sets the zilla version to use                                      [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
-         --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
+         --no-kafka-init  The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]
          --help           Print help                                                                         [boolean]
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install and run any of the [examples](#examples) using the `startup.sh` script:
 You can specify your own Kafka host and port or the working directory where you want the examples to be downloaded. Existing example directories will `not` be overwritten.
 
 ```bash
-./startup.sh -m -h kafka -p 9092 -d /tmp example.name
+./startup.sh -m -k kafka:9092 -d /tmp example.name
 ```
 
 Alternatively, you can run this script the same way without cloning the repo.
@@ -41,18 +41,17 @@ wget -qO- https://raw.githubusercontent.com/aklivity/zilla-examples/main/startup
 ```
 
 ```text
-Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-kafka-init][--redpanda] example.name
+Usage: startup.sh [-hm][-k KAFKA_BOOTSTRAP_SERVER][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-kafka-init][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
 
 Options:
-    -e | --ex-version     Sets the examples version to download                              [default: latest][string]
     -d | --workdir        Sets the directory used to download and run the example                             [string]
-    -h | --kafka-host     Sets the hostname used when connecting to Kafka                                     [string]
-    -k | --use-helm       Use the helm install, if available, instead of compose                             [boolean]
+    -e | --ex-version     Sets the examples version to download                              [default: latest][string]
+    -h | --use-helm       Use the helm install, if available, instead of compose                             [boolean]
+    -k | --kafka-server   Sets the Kafka Boostrap Server to use                                               [string]
     -m | --use-main       Download the head of the main branch                                               [boolean]
-    -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
     -v | --zilla-version  Sets the zilla version to use                                      [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
          --no-kafka-init  The script wont try to bootstrap the kafka broker                                  [boolean]
@@ -80,7 +79,7 @@ Options:
 | [http.kafka.oneway](http.kafka.oneway)                             | Sends messages to a Kafka topic, fire-and-forget                                                    |
 | [http.kafka.crud](http.kafka.crud)                                 | Exposes a REST API with CRUD operations where a log-compacted Kafka topic acts as a table           |
 | [http.kafka.sasl.scram](http.kafka.sasl.scram)                     | Sends messages to a SASL/SCRAM enabled Kafka                                                        |
-| [http.kafka.karapace](http.kafka.karapace)           | Validate messages while produce and fetch to a Kafka topic                                          |
+| [http.kafka.karapace](http.kafka.karapace)                         | Validate messages while produce and fetch to a Kafka topic                                          |
 | [http.redpanda.sasl.scram](http.redpanda.sasl.scram)               | Sends messages to a SASL/SCRAM enabled Redpanda Cluster                                             |
 | [kubernetes.prometheus.autoscale](kubernetes.prometheus.autoscale) | Demo Kubernetes Horizontal Pod Autoscaling feature based a on a custom metric with Prometheus       |
 | [grpc.echo](grpc.echo)                                             | Echoes messages sent to the gRPC server from a gRPC client                                          |

--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ wget -qO- https://raw.githubusercontent.com/aklivity/zilla-examples/main/startup
 ```
 
 ```text
-Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-bootstrap][--auto-teardown][--redpanda] example.name
+Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-bootstrap][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
 
 Options:
+    -e | --ex-version     Sets the examples version to download                              [default: latest][string]
     -d | --workdir        Sets the directory used to download and run the example                             [string]
     -h | --kafka-host     Sets the hostname used when connecting to Kafka                                     [string]
     -k | --use-helm       Use the helm install, if available, instead of compose                             [boolean]
     -m | --use-main       Download the head of the main branch                                               [boolean]
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
-    -v | --version        Sets the version to download                                       [default: latest][string]
+    -v | --zilla-version  Sets the zilla version to use                                      [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
          --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wget -qO- https://raw.githubusercontent.com/aklivity/zilla-examples/main/startup
 ```
 
 ```text
-Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-kafka][--auto-teardown][--redpanda] example.name
+Usage: startup.sh [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-bootstrap][--auto-teardown][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
@@ -54,7 +54,7 @@ Options:
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
     -v | --version        Sets the version to download                                       [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
-         --no-kafka       The script wont try to start a kafka broker                                        [boolean]
+         --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]
          --help           Print help                                                                         [boolean]
 ```

--- a/amqp.reflect/setup.sh
+++ b/amqp.reflect/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-amqp-reflect
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-amqp-reflect}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/amqp.reflect/setup.sh
+++ b/amqp.reflect/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-amqp-reflect}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/amqp.reflect/teardown.sh
+++ b/amqp.reflect/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-amqp-reflect
+NAMESPACE="${NAMESPACE:-zilla-amqp-reflect}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/grpc.echo/setup.sh
+++ b/grpc.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-grpc-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-grpc-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/grpc.echo/setup.sh
+++ b/grpc.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-grpc-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.proto.data.echo\\.proto=proto/echo.proto \

--- a/grpc.echo/teardown.sh
+++ b/grpc.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-grpc-echo
+NAMESPACE="${NAMESPACE:-zilla-grpc-echo}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/grpc.kafka.echo/setup.sh
+++ b/grpc.kafka.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.proto.data.echo\\.proto=proto/echo.proto \

--- a/grpc.kafka.echo/setup.sh
+++ b/grpc.kafka.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-grpc-kafka-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/grpc.kafka.echo/teardown.sh
+++ b/grpc.kafka.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-grpc-kafka-echo
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-echo}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/grpc.kafka.echo/zilla.yaml
+++ b/grpc.kafka.echo/zilla.yaml
@@ -87,16 +87,13 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
 telemetry:
   exporters:
     stdout_exporter:

--- a/grpc.kafka.fanout/setup.sh
+++ b/grpc.kafka.fanout/setup.sh
@@ -2,8 +2,9 @@
 set -ex
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-fanout}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.proto.data.fanout\\.proto=proto/fanout.proto \

--- a/grpc.kafka.fanout/setup.sh
+++ b/grpc.kafka.fanout/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-grpc-kafka-fanout
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-fanout}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/grpc.kafka.fanout/teardown.sh
+++ b/grpc.kafka.fanout/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-grpc-kafka-fanout
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-fanout}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/grpc.kafka.fanout/zilla.yaml
+++ b/grpc.kafka.fanout/zilla.yaml
@@ -79,16 +79,13 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
 telemetry:
   exporters:
     stdout_exporter:

--- a/grpc.kafka.proxy/setup.sh
+++ b/grpc.kafka.proxy/setup.sh
@@ -5,8 +5,8 @@ set -ex
 docker image inspect zilla-examples/grpc-echo:latest --format 'Image Found {{.RepoTags}}'
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-grpc-kafka-proxy
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-proxy}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/grpc.kafka.proxy/setup.sh
+++ b/grpc.kafka.proxy/setup.sh
@@ -6,8 +6,9 @@ docker image inspect zilla-examples/grpc-echo:latest --format 'Image Found {{.Re
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-proxy}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.proto.data.echo\\.proto=proto/echo.proto \

--- a/grpc.kafka.proxy/teardown.sh
+++ b/grpc.kafka.proxy/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-grpc-kafka-proxy
+NAMESPACE="${NAMESPACE:-zilla-grpc-kafka-proxy}"
 helm uninstall zilla grpc-echo-kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/grpc.kafka.proxy/zilla.yaml
+++ b/grpc.kafka.proxy/zilla.yaml
@@ -82,16 +82,13 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
-    exit: south_kafka_tcp_client
-  south_kafka_tcp_client:
+    options:
+      servers:
+        - kafka:29092
+    exit: south_tcp_client
+  south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
   west_kafka_grpc_remote_server:
     type: kafka-grpc
     kind: remote_server

--- a/grpc.proxy/setup.sh
+++ b/grpc.proxy/setup.sh
@@ -5,8 +5,8 @@ set -ex
 docker image inspect zilla-examples/grpc-echo:latest --format 'Image Found {{.RepoTags}}'
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-grpc-proxy
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-grpc-proxy}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/grpc.proxy/setup.sh
+++ b/grpc.proxy/setup.sh
@@ -6,8 +6,9 @@ docker image inspect zilla-examples/grpc-echo:latest --format 'Image Found {{.Re
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-grpc-proxy}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.proto.data.echo\\.proto=proto/echo.proto \

--- a/grpc.proxy/teardown.sh
+++ b/grpc.proxy/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Grpc Echo
-NAMESPACE=zilla-grpc-proxy
+NAMESPACE="${NAMESPACE:-zilla-grpc-proxy}"
 helm uninstall zilla grpc-echo --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.echo.jwt/setup.sh
+++ b/http.echo.jwt/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-echo-jwt}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.echo.jwt/setup.sh
+++ b/http.echo.jwt/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-echo-jwt
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-echo-jwt}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.echo.jwt/teardown.sh
+++ b/http.echo.jwt/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-http-echo-jwt
+NAMESPACE="${NAMESPACE:-zilla-http-echo-jwt}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.echo/setup.sh
+++ b/http.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.echo/setup.sh
+++ b/http.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.echo/teardown.sh
+++ b/http.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-http-echo
+NAMESPACE="${NAMESPACE:-zilla-http-echo}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.filesystem.config.server/change_config.sh
+++ b/http.filesystem.config.server/change_config.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # change configfile
-NAMESPACE=zilla-config-server
+NAMESPACE="${NAMESPACE:-zilla-config-server}"
 ZILLA_CONFIG_POD=$(kubectl get pods --namespace $NAMESPACE --selector app.kubernetes.io/instance=zilla-config -o json | jq -r '.items[0].metadata.name')
 kubectl cp --namespace $NAMESPACE www-updated/zilla.yaml "$ZILLA_CONFIG_POD:/var/www/zilla.yaml"
 

--- a/http.filesystem.config.server/setup.sh
+++ b/http.filesystem.config.server/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla (config) to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-config-server}"
-helm upgrade --install zilla-config $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla-config $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values zilla-config/values.yaml \
     --set-file zilla\\.yaml=zilla-config/zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12
@@ -14,7 +15,7 @@ ZILLA_CONFIG_POD=$(kubectl get pods --namespace $NAMESPACE --selector app.kubern
 kubectl cp --namespace $NAMESPACE www "$ZILLA_CONFIG_POD:/var/"
 
 # Install Zilla (http) to the Kubernetes cluster with helm and wait for the pod to start up
-helm upgrade --install zilla-http $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla-http $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values zilla-http/values.yaml \
     --set-file configMaps.prop.data.zilla\\.properties=zilla-http/zilla.properties
 

--- a/http.filesystem.config.server/setup.sh
+++ b/http.filesystem.config.server/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla (config) to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-config-server
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-config-server}"
 helm upgrade --install zilla-config $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values zilla-config/values.yaml \
     --set-file zilla\\.yaml=zilla-config/zilla.yaml \

--- a/http.filesystem.config.server/teardown.sh
+++ b/http.filesystem.config.server/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-config-server
+NAMESPACE="${NAMESPACE:-zilla-config-server}"
 helm uninstall zilla-config zilla-http --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.filesystem/setup.sh
+++ b/http.filesystem/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-filesystem}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.filesystem/setup.sh
+++ b/http.filesystem/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-filesystem
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-filesystem}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.filesystem/teardown.sh
+++ b/http.filesystem/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-http-filesystem
+NAMESPACE="${NAMESPACE:-zilla-http-filesystem}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.async/setup.sh
+++ b/http.kafka.async/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-async
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-async}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.async/setup.sh
+++ b/http.kafka.async/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-async}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.async/teardown.sh
+++ b/http.kafka.async/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-async
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-async}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.async/zilla.yaml
+++ b/http.kafka.async/zilla.yaml
@@ -80,13 +80,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.cache/setup.sh
+++ b/http.kafka.cache/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-cache}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.cache/setup.sh
+++ b/http.kafka.cache/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-cache
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-cache}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.cache/teardown.sh
+++ b/http.kafka.cache/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-cache
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-cache}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.cache/zilla.yaml
+++ b/http.kafka.cache/zilla.yaml
@@ -85,13 +85,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.crud/setup.sh
+++ b/http.kafka.crud/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-crud
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-crud}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.crud/setup.sh
+++ b/http.kafka.crud/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-crud}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.crud/teardown.sh
+++ b/http.kafka.crud/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-crud
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-crud}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.crud/zilla.yaml
+++ b/http.kafka.crud/zilla.yaml
@@ -109,13 +109,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.karapace/setup.sh
+++ b/http.kafka.karapace/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-karapace}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.karapace/setup.sh
+++ b/http.kafka.karapace/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-karapace
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-karapace}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.karapace/teardown.sh
+++ b/http.kafka.karapace/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-karapace
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-karapace}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.karapace/zilla.yaml
+++ b/http.kafka.karapace/zilla.yaml
@@ -134,13 +134,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.oneway/setup.sh
+++ b/http.kafka.oneway/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-oneway}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.oneway/setup.sh
+++ b/http.kafka.oneway/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-oneway
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-oneway}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.oneway/teardown.sh
+++ b/http.kafka.oneway/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-oneway
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-oneway}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.oneway/zilla.yaml
+++ b/http.kafka.oneway/zilla.yaml
@@ -70,13 +70,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.sasl.scram/setup.sh
+++ b/http.kafka.sasl.scram/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-sasl-scram
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-sasl-scram}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.sasl.scram/setup.sh
+++ b/http.kafka.sasl.scram/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-sasl-scram}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.sasl.scram/teardown.sh
+++ b/http.kafka.sasl.scram/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-sasl-scram
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-sasl-scram}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.sasl.scram/zilla.yaml
+++ b/http.kafka.sasl.scram/zilla.yaml
@@ -71,6 +71,8 @@ bindings:
     type: kafka
     kind: client
     options:
+      servers:
+        - kafka:29092
       sasl:
         mechanism: scram-sha-256
         username: ${{env.SASL_USERNAME}}
@@ -79,9 +81,3 @@ bindings:
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29091
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/http.kafka.sync/setup.sh
+++ b/http.kafka.sync/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-kafka-sync}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.kafka.sync/setup.sh
+++ b/http.kafka.sync/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-kafka-sync
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-sync}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.kafka.sync/teardown.sh
+++ b/http.kafka.sync/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-http-kafka-sync
+NAMESPACE="${NAMESPACE:-zilla-http-kafka-sync}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.kafka.sync/zilla.yaml
+++ b/http.kafka.sync/zilla.yaml
@@ -105,6 +105,9 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
     telemetry:
       metrics:
@@ -112,12 +115,6 @@ bindings:
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
     telemetry:
       metrics:
         - stream.*

--- a/http.proxy.schema.inline/setup.sh
+++ b/http.proxy.schema.inline/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-proxy-schema-inline}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12 \

--- a/http.proxy.schema.inline/setup.sh
+++ b/http.proxy.schema.inline/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-proxy-schema-inline
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-proxy-schema-inline}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.proxy.schema.inline/teardown.sh
+++ b/http.proxy.schema.inline/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Nginx
-NAMESPACE=zilla-http-proxy-schema-inline
+NAMESPACE="${NAMESPACE:-zilla-http-proxy-schema-inline}"
 helm uninstall zilla nginx --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.proxy/setup.sh
+++ b/http.proxy/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-proxy
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-proxy}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.proxy/setup.sh
+++ b/http.proxy/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-proxy}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12 \

--- a/http.proxy/teardown.sh
+++ b/http.proxy/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Nginx
-NAMESPACE=zilla-http-proxy
+NAMESPACE="${NAMESPACE:-zilla-http-proxy}"
 helm uninstall zilla nginx --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/http.redpanda.sasl.scram/setup.sh
+++ b/http.redpanda.sasl.scram/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-http-redpanda-sasl-scram
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-http-redpanda-sasl-scram}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/http.redpanda.sasl.scram/setup.sh
+++ b/http.redpanda.sasl.scram/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-http-redpanda-sasl-scram}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/http.redpanda.sasl.scram/teardown.sh
+++ b/http.redpanda.sasl.scram/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Redpanda
-NAMESPACE=zilla-http-redpanda-sasl-scram
+NAMESPACE="${NAMESPACE:-zilla-http-redpanda-sasl-scram}"
 helm uninstall zilla redpanda --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/kafka.broker/docker/compose/setup.sh
+++ b/kafka.broker/docker/compose/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-kafka-broker
+NAMESPACE=${NAMESPACE:-zilla-kafka-broker}
 
 if [[ -z $(docker-compose -p $NAMESPACE ps -q kafka) || -z $(docker-compose -p $NAMESPACE ps -q kafka-ui) ]]; then
   docker-compose -p $NAMESPACE up -d

--- a/kafka.broker/docker/compose/setup.sh
+++ b/kafka.broker/docker/compose/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=${NAMESPACE:-zilla-kafka-broker}
+NAMESPACE="${NAMESPACE:-zilla-kafka-broker}"
 
 if [[ -z $(docker-compose -p $NAMESPACE ps -q kafka) || -z $(docker-compose -p $NAMESPACE ps -q kafka-ui) ]]; then
   docker-compose -p $NAMESPACE up -d

--- a/kafka.broker/docker/compose/teardown.sh
+++ b/kafka.broker/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
+NAMESPACE="${NAMESPACE:-zilla-kafka-broker}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/kafka.broker/docker/compose/teardown.sh
+++ b/kafka.broker/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/kafka.broker/k8s/helm/setup.sh
+++ b/kafka.broker/k8s/helm/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
+NAMESPACE="${NAMESPACE:-zilla-kafka-broker}"
 # Install Kafka to the Kubernetes cluster with helm and wait for the pod to start up
 helm upgrade --install kafka . --namespace $NAMESPACE --create-namespace --wait
 helm upgrade --install kafka-ui kafka-ui --version 0.7.5 --namespace $NAMESPACE --repo https://provectus.github.io/kafka-ui-charts --wait \

--- a/kafka.broker/k8s/helm/setup.sh
+++ b/kafka.broker/k8s/helm/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
 # Install Kafka to the Kubernetes cluster with helm and wait for the pod to start up
 helm upgrade --install kafka . --namespace $NAMESPACE --create-namespace --wait
 helm upgrade --install kafka-ui kafka-ui --version 0.7.5 --namespace $NAMESPACE --repo https://provectus.github.io/kafka-ui-charts --wait \

--- a/kafka.broker/k8s/helm/teardown.sh
+++ b/kafka.broker/k8s/helm/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
 helm uninstall kafka kafka-ui --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/kafka.broker/k8s/helm/teardown.sh
+++ b/kafka.broker/k8s/helm/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
+NAMESPACE="${NAMESPACE:-zilla-kafka-broker}"
 helm uninstall kafka kafka-ui --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/kubernetes.prometheus.autoscale/check_hpa.sh
+++ b/kubernetes.prometheus.autoscale/check_hpa.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 BOLD='\033[1;97m'
 END='\033[0m'
-NAMESPACE=zilla-kubernetes-prometheus-autoscale
+NAMESPACE="${NAMESPACE:-zilla-kubernetes-prometheus-autoscale}"
 
 echo -e "${BOLD}The status of horizontal pod autoscaling${END}"
 echo -e "${BOLD}----------------------------------------${END}\n"

--- a/kubernetes.prometheus.autoscale/check_metric.sh
+++ b/kubernetes.prometheus.autoscale/check_metric.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 BOLD='\033[1;97m'
 END='\033[0m'
-NAMESPACE=zilla-kubernetes-prometheus-autoscale
+NAMESPACE="${NAMESPACE:-zilla-kubernetes-prometheus-autoscale}"
 
 echo -e "${BOLD}The value of stream_active_received metric${END}"
 echo -e "${BOLD}------------------------------------------${END}\n"

--- a/kubernetes.prometheus.autoscale/setup.sh
+++ b/kubernetes.prometheus.autoscale/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-kubernetes-prometheus-autoscale}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml
 

--- a/kubernetes.prometheus.autoscale/setup.sh
+++ b/kubernetes.prometheus.autoscale/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-kubernetes-prometheus-autoscale
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-kubernetes-prometheus-autoscale}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml

--- a/kubernetes.prometheus.autoscale/teardown.sh
+++ b/kubernetes.prometheus.autoscale/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla, Prometheus and Prometheus Adapter
-NAMESPACE=zilla-kubernetes-prometheus-autoscale
+NAMESPACE="${NAMESPACE:-zilla-kubernetes-prometheus-autoscale}"
 helm uninstall zilla prometheus --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/mqtt.kafka.asyncapi.proxy/README.md
+++ b/mqtt.kafka.asyncapi.proxy/README.md
@@ -7,7 +7,7 @@ Zilla implements MQTT API defined in AsyncAPI specifications and uses Kafka API 
 
 This example can be run using Docker compose or Kubernetes. The setup scripts are in the [compose](./docker/compose) and [helm](./k8s/helm) folders respectively and work the same way.
 
-You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder.
+You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder. Alternatively you can use the [redpanda.broker](../redpanda.broker) folder.
 
 ### Setup
 

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/docker-compose.yaml
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION}
     container_name: zilla
     pull_policy: always
     restart: unless-stopped

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
@@ -6,7 +6,7 @@ export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
-BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
@@ -14,7 +14,7 @@ if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
   docker-compose -p $NAMESPACE up -d
 
   # Create the mqtt topics in Kafka
-  if [[ $BOOTSTRAP_KAFKA == true ]]; then
+  if [[ $INIT_KAFKA == true ]]; then
     docker run --rm bitnami/kafka:3.2 bash -c "
     echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
     /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 set -e
 
-if [[ -z "$KAFKA_HOST" && -z "$KAFKA_PORT" ]]; then
-  export KAFKA_HOST=host.docker.internal
-  export KAFKA_PORT=9092
-  echo "==== This example requires env vars KAFKA_HOST and KAFKA_PORT for a running kafka instance. Setting to the default ($KAFKA_HOST:$KAFKA_PORT) ===="
-fi
-
-NAMESPACE=zilla-mqtt-kafka-asyncapi-proxy
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
+export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
+export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
   docker-compose -p $NAMESPACE up -d
 
   # Create the mqtt topics in Kafka
-  docker run --rm bitnami/kafka:3.2 bash -c "
-  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
-  "
+  if [[ $BOOTSTRAP_KAFKA == true ]]; then
+    docker run --rm bitnami/kafka:3.2 bash -c "
+    echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+    "
+  fi
 
 else
   docker-compose -p $NAMESPACE restart --no-deps zilla

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
+export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/setup.sh
@@ -4,23 +4,23 @@ set -e
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
-export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_BOOTSTRAP_SERVER="${KAFKA_BOOTSTRAP_SERVER:-host.docker.internal:9092}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
 INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
-  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_BOOTSTRAP_SERVER) ===="
   docker-compose -p $NAMESPACE up -d
 
   # Create the mqtt topics in Kafka
   if [[ $INIT_KAFKA == true ]]; then
     docker run --rm bitnami/kafka:3.2 bash -c "
-    echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+    echo 'Creating topics for $KAFKA_BOOTSTRAP_SERVER'
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic streetlights
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
     "
   fi
 

--- a/mqtt.kafka.asyncapi.proxy/docker/compose/teardown.sh
+++ b/mqtt.kafka.asyncapi.proxy/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-mqtt-kafka-asyncapi-proxy
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
@@ -4,13 +4,13 @@ set -e
 ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
-export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_BOOTSTRAP_SERVER="${KAFKA_BOOTSTRAP_SERVER:-host.docker.internal:9092}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
 INIT_KAFKA="${INIT_KAFKA:-true}"
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
+echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_BOOTSTRAP_SERVER) ===="
 helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
@@ -21,11 +21,11 @@ helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $
 # Create the mqtt topics in Kafka
 if [[ $INIT_KAFKA == true ]]; then
   kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
-  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+  echo 'Creating topics for $KAFKA_BOOTSTRAP_SERVER'
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-messages
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic streetlights
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
   "
   kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
 fi

--- a/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
@@ -10,7 +11,7 @@ ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
     --set-file zilla\\.yaml=../../zilla.yaml \

--- a/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
@@ -6,7 +6,7 @@ NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
-BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+INIT_KAFKA="${INIT_KAFKA:-true}"
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
@@ -19,7 +19,7 @@ helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $
     --set-file configMaps.specs.data.kafka-asyncapi\\.yaml=../../specs/kafka-asyncapi.yaml
 
 # Create the mqtt topics in Kafka
-if [[ $BOOTSTRAP_KAFKA == true ]]; then
+if [[ $INIT_KAFKA == true ]]; then
   kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
   echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
   /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages

--- a/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
+++ b/mqtt.kafka.asyncapi.proxy/k8s/helm/setup.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-if [[ -z "$KAFKA_HOST" && -z "$KAFKA_PORT" ]]; then
-  export KAFKA_HOST=kafka.zilla-kafka-broker.svc.cluster.local
-  export KAFKA_PORT=9092
-  echo "==== This example requires env vars KAFKA_HOST and KAFKA_PORT for a running kafka instance. Setting to the default ($KAFKA_HOST:$KAFKA_PORT) ===="
-fi
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
+export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
+export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-NAMESPACE=zilla-mqtt-kafka-asyncapi-proxy
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-echo "Installing $ZILLA_CHART to $NAMESPACE with Kafka at $KAFKA_HOST:$KAFKA_PORT"
+echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
@@ -19,14 +18,16 @@ helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namesp
     --set-file configMaps.specs.data.kafka-asyncapi\\.yaml=../../specs/kafka-asyncapi.yaml
 
 # Create the mqtt topics in Kafka
-kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
-echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
-"
-kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
+if [[ $BOOTSTRAP_KAFKA == true ]]; then
+  kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
+  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic streetlights
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+  "
+  kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
+fi
 
 # Start port forwarding
 SERVICE_PORTS=$(kubectl get svc --namespace $NAMESPACE zilla --template "{{ range .spec.ports }}{{.port}} {{ end }}")

--- a/mqtt.kafka.asyncapi.proxy/k8s/helm/teardown.sh
+++ b/mqtt.kafka.asyncapi.proxy/k8s/helm/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-mqtt-kafka-asyncapi-proxy
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-asyncapi-proxy}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/mqtt.kafka.broker.jwt/setup.sh
+++ b/mqtt.kafka.broker.jwt/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-mqtt-kafka-broker-jwt
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker-jwt}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/mqtt.kafka.broker.jwt/setup.sh
+++ b/mqtt.kafka.broker.jwt/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker-jwt}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/mqtt.kafka.broker.jwt/teardown.sh
+++ b/mqtt.kafka.broker.jwt/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-mqtt-kafka-broker-jwt
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker-jwt}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/mqtt.kafka.broker.jwt/zilla.yaml
+++ b/mqtt.kafka.broker.jwt/zilla.yaml
@@ -84,13 +84,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/mqtt.kafka.broker/README.md
+++ b/mqtt.kafka.broker/README.md
@@ -6,7 +6,7 @@ This is the resource folder for the running the [MQTT Kafka broker guide](https:
 
 This example can be run using Docker compose or Kubernetes. The setup scripts are in the [compose](./docker/compose) and [helm](./k8s/helm) folders respectively and work the same way.
 
-You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder.
+You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder. Alternatively you can use the [redpanda.broker](../redpanda.broker) folder.
 
 ### Setup
 

--- a/mqtt.kafka.broker/docker/compose/docker-compose.yaml
+++ b/mqtt.kafka.broker/docker/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION}
     container_name: zilla
     pull_policy: always
     restart: unless-stopped

--- a/mqtt.kafka.broker/docker/compose/setup.sh
+++ b/mqtt.kafka.broker/docker/compose/setup.sh
@@ -6,14 +6,14 @@ export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
-BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
   echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
   docker-compose -p $NAMESPACE up -d
 
-  if [[ $BOOTSTRAP_KAFKA == true ]]; then
+  if [[ $INIT_KAFKA == true ]]; then
     # Create the mqtt topics in Kafka
     docker run --rm bitnami/kafka:3.2 bash -c "
     echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'

--- a/mqtt.kafka.broker/docker/compose/setup.sh
+++ b/mqtt.kafka.broker/docker/compose/setup.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 set -e
 
-if [[ -z "$KAFKA_HOST" && -z "$KAFKA_PORT" ]]; then
-  export KAFKA_HOST=host.docker.internal
-  export KAFKA_PORT=9092
-  echo "==== This example requires env vars KAFKA_HOST and KAFKA_PORT for a running kafka instance. Setting to the default ($KAFKA_HOST:$KAFKA_PORT) ===="
-fi
-
-NAMESPACE=zilla-mqtt-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
+export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
+export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
   docker-compose -p $NAMESPACE up -d
 
-  if [[ "$KAFKA_SKIP_CREATE_TOPICS" != "yes" ]]; then
+  if [[ $BOOTSTRAP_KAFKA == true ]]; then
     # Create the mqtt topics in Kafka
     docker run --rm bitnami/kafka:3.2 bash -c "
     echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'

--- a/mqtt.kafka.broker/docker/compose/setup.sh
+++ b/mqtt.kafka.broker/docker/compose/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
+export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"

--- a/mqtt.kafka.broker/docker/compose/setup.sh
+++ b/mqtt.kafka.broker/docker/compose/setup.sh
@@ -4,23 +4,23 @@ set -e
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
-export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_BOOTSTRAP_SERVER="${KAFKA_BOOTSTRAP_SERVER:-host.docker.internal:9092}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
 INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
-  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_BOOTSTRAP_SERVER) ===="
   docker-compose -p $NAMESPACE up -d
 
   if [[ $INIT_KAFKA == true ]]; then
     # Create the mqtt topics in Kafka
     docker run --rm bitnami/kafka:3.2 bash -c "
-    echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+    echo 'Creating topics for $KAFKA_BOOTSTRAP_SERVER'
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
     "
   fi
 

--- a/mqtt.kafka.broker/docker/compose/teardown.sh
+++ b/mqtt.kafka.broker/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-mqtt-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -4,13 +4,13 @@ set -e
 ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
-export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_BOOTSTRAP_SERVER="${KAFKA_BOOTSTRAP_SERVER:-host.docker.internal:9092}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
 INIT_KAFKA="${INIT_KAFKA:-true}"
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
+echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_BOOTSTRAP_SERVER) ===="
 helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
@@ -20,11 +20,11 @@ helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $
 # Create the mqtt topics in Kafka
 if [[ $INIT_KAFKA == true ]]; then
   kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
-  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+  echo 'Creating topics for $KAFKA_BOOTSTRAP_SERVER'
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-messages
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
   "
   kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
 fi

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-if [[ -z "$KAFKA_HOST" && -z "$KAFKA_PORT" ]]; then
-  export KAFKA_HOST=kafka.zilla-kafka-broker.svc.cluster.local
-  export KAFKA_PORT=9092
-  echo "==== This example requires env vars KAFKA_HOST and KAFKA_PORT for a running kafka instance. Setting to the default ($KAFKA_HOST:$KAFKA_PORT) ===="
-fi
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
+export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
+export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-NAMESPACE=zilla-mqtt-kafka-broker
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-echo "Installing $ZILLA_CHART to $NAMESPACE with Kafka at $KAFKA_HOST:$KAFKA_PORT"
+echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
@@ -18,15 +17,15 @@ helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namesp
     --set-file secrets.tls.data.localhost\\.p12=../../tls/localhost.p12
 
 # Create the mqtt topics in Kafka
-if [[ "$KAFKA_SKIP_CREATE_TOPICS" != "yes" ]]; then
-kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
-echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
-/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
-"
-kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
+if [[ $BOOTSTRAP_KAFKA == true ]]; then
+  kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
+  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-devices --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-retained --config cleanup.policy=compact
+  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-sessions --config cleanup.policy=compact
+  "
+  kubectl wait --namespace $NAMESPACE --for=delete pod/kafka-init-pod
 fi
 
 # Start port forwarding

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -6,7 +6,7 @@ NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
-BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+INIT_KAFKA="${INIT_KAFKA:-true}"
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
@@ -18,7 +18,7 @@ helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $
     --set-file secrets.tls.data.localhost\\.p12=../../tls/localhost.p12
 
 # Create the mqtt topics in Kafka
-if [[ $BOOTSTRAP_KAFKA == true ]]; then
+if [[ $INIT_KAFKA == true ]]; then
   kubectl run kafka-init-pod --image=bitnami/kafka:3.2 --namespace $NAMESPACE --rm --restart=Never -i -t -- /bin/sh -c "
   echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
   /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic mqtt-messages

--- a/mqtt.kafka.broker/k8s/helm/setup.sh
+++ b/mqtt.kafka.broker/k8s/helm/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
@@ -10,7 +11,7 @@ ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 echo "==== Installing $ZILLA_CHART to $NAMESPACE with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set extraEnv[1].value="\"$KAFKA_HOST\"",extraEnv[2].value="\"$KAFKA_PORT\"" \
     --set-file zilla\\.yaml=../../zilla.yaml \

--- a/mqtt.kafka.broker/k8s/helm/teardown.sh
+++ b/mqtt.kafka.broker/k8s/helm/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-mqtt-kafka-broker
+NAMESPACE="${NAMESPACE:-zilla-mqtt-kafka-broker}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/mqtt.kafka.broker/zilla.yaml
+++ b/mqtt.kafka.broker/zilla.yaml
@@ -120,16 +120,13 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        -  ${{env.KAFKA_BOOTSTRAP_SERVER}}
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: ${{env.KAFKA_HOST}}
-      port: ${{env.KAFKA_PORT}}
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
 
 vaults:
   my_servers:

--- a/mqtt.proxy.asyncapi/setup.sh
+++ b/mqtt.proxy.asyncapi/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-mqtt-proxy-asyncapi}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file configMaps.asyncapi.data.mqtt-asyncapi\\.yaml=mqtt-asyncapi.yaml

--- a/mqtt.proxy.asyncapi/setup.sh
+++ b/mqtt.proxy.asyncapi/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=mqtt-proxy-asyncapi
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-mqtt-proxy-asyncapi}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/mqtt.proxy.asyncapi/teardown.sh
+++ b/mqtt.proxy.asyncapi/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and mosquitto
-NAMESPACE=mqtt-proxy-asyncapi
+NAMESPACE="${NAMESPACE:-mqtt-proxy-asyncapi}"
 helm uninstall zilla mosquitto --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/openapi.proxy/docker/compose/docker-compose.yaml
+++ b/openapi.proxy/docker/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:latest
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION}
     container_name: zilla
     pull_policy: always
     restart: unless-stopped

--- a/openapi.proxy/docker/compose/setup.sh
+++ b/openapi.proxy/docker/compose/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-openapi-proxy
+NAMESPACE="${NAMESPACE:-zilla-openapi-proxy}"
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
   docker-compose -p $NAMESPACE up -d

--- a/openapi.proxy/docker/compose/setup.sh
+++ b/openapi.proxy/docker/compose/setup.sh
@@ -2,6 +2,8 @@
 set -e
 
 NAMESPACE="${NAMESPACE:-zilla-openapi-proxy}"
+export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
+
 # Start or restart Zilla
 if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
   docker-compose -p $NAMESPACE up -d

--- a/openapi.proxy/docker/compose/teardown.sh
+++ b/openapi.proxy/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-openapi-proxy
+NAMESPACE="${NAMESPACE:-zilla-openapi-proxy}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -6,7 +6,7 @@ Follow the [Zilla Quickstart](https://docs.aklivity.io/zilla/latest/tutorials/qu
 
 This quickstart runs using Docker compose. You will find the setup scripts in the [compose](./docker/compose) folder.
 
-You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder.
+You will need a running kafka broker. To start one locally you will find instructions in the [kafka.broker](../kafka.broker) folder. Alternatively you can use the [redpanda.broker](../redpanda.broker) folder.
 
 ### Setup
 

--- a/quickstart/docker/compose/docker-compose.yaml
+++ b/quickstart/docker/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:latest
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION}
     container_name: zilla
     pull_policy: always
     restart: unless-stopped

--- a/quickstart/docker/compose/setup.sh
+++ b/quickstart/docker/compose/setup.sh
@@ -6,14 +6,14 @@ export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"
-BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
+INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p "$NAMESPACE" ps -q zilla) ]]; then
   echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
   docker-compose -p $NAMESPACE up -d
 
-  if [[ $BOOTSTRAP_KAFKA == true ]]; then
+  if [[ $INIT_KAFKA == true ]]; then
     docker run --rm bitnami/kafka bash -c "
     echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
     /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic items-crud --config cleanup.policy=compact

--- a/quickstart/docker/compose/setup.sh
+++ b/quickstart/docker/compose/setup.sh
@@ -4,26 +4,25 @@ set -e
 NAMESPACE="${NAMESPACE:-zilla-quickstart}"
 export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
-export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
-export KAFKA_PORT="${KAFKA_PORT:-9092}"
+export KAFKA_BOOTSTRAP_SERVER="${KAFKA_BOOTSTRAP_SERVER:-host.docker.internal:9092}"
 INIT_KAFKA="${INIT_KAFKA:-true}"
 
 # Start or restart Zilla
 if [[ -z $(docker-compose -p "$NAMESPACE" ps -q zilla) ]]; then
-  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_BOOTSTRAP_SERVER) ===="
   docker-compose -p $NAMESPACE up -d
 
   if [[ $INIT_KAFKA == true ]]; then
     docker run --rm bitnami/kafka bash -c "
-    echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic items-crud --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic events-sse --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic echo-service-messages
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-requests
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-responses
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-messages
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-retained --config cleanup.policy=compact
-    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-sessions --config cleanup.policy=compact
+    echo 'Creating topics for $KAFKA_BOOTSTRAP_SERVER'
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic items-crud --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic events-sse --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic echo-service-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic route-guide-requests
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic route-guide-responses
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic iot-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic iot-retained --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_BOOTSTRAP_SERVER --create --if-not-exists --topic iot-sessions --config cleanup.policy=compact
     "
   fi
 

--- a/quickstart/docker/compose/setup.sh
+++ b/quickstart/docker/compose/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 NAMESPACE="${NAMESPACE:-zilla-quickstart}"
+export ZILLA_VERSION="${ZILLA_VERSION:-latest}"
 export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
 export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
 export KAFKA_PORT="${KAFKA_PORT:-9092}"

--- a/quickstart/docker/compose/setup.sh
+++ b/quickstart/docker/compose/setup.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
 set -e
 
-if [[ -z "$KAFKA_HOST" && -z "$KAFKA_PORT" ]]; then
-  export KAFKA_HOST=host.docker.internal
-  export KAFKA_PORT=9092
-  echo "==== This example requires env vars KAFKA_HOST and KAFKA_PORT for a running kafka instance. Setting to the default ($KAFKA_HOST:$KAFKA_PORT) ===="
-fi
-
-NAMESPACE=zilla-quickstart
+NAMESPACE="${NAMESPACE:-zilla-quickstart}"
+export KAFKA_BROKER="${KAFKA_BROKER:-kafka}"
+export KAFKA_HOST="${KAFKA_HOST:-host.docker.internal}"
+export KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP_KAFKA="${BOOTSTRAP_KAFKA:-true}"
 
 # Start or restart Zilla
-if [[ -z $(docker-compose -p $NAMESPACE ps -q zilla) ]]; then
+if [[ -z $(docker-compose -p "$NAMESPACE" ps -q zilla) ]]; then
+  echo "==== Running the $NAMESPACE example with $KAFKA_BROKER($KAFKA_HOST:$KAFKA_PORT) ===="
   docker-compose -p $NAMESPACE up -d
 
-  docker run --rm bitnami/kafka bash -c "
-  echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic items-crud --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic events-sse --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic echo-service-messages
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-requests
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-responses
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-messages
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-retained --config cleanup.policy=compact
-  /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-sessions --config cleanup.policy=compact
-  "
+  if [[ $BOOTSTRAP_KAFKA == true ]]; then
+    docker run --rm bitnami/kafka bash -c "
+    echo 'Creating topics for $KAFKA_HOST:$KAFKA_PORT'
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic items-crud --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic events-sse --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic echo-service-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-requests
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic route-guide-responses
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-messages
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-retained --config cleanup.policy=compact
+    /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server $KAFKA_HOST:$KAFKA_PORT --create --if-not-exists --topic iot-sessions --config cleanup.policy=compact
+    "
+  fi
 
 else
   docker-compose -p $NAMESPACE restart --no-deps zilla

--- a/quickstart/docker/compose/teardown.sh
+++ b/quickstart/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-quickstart
+NAMESPACE="${NAMESPACE:-zilla-quickstart}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/quickstart/zilla.yaml
+++ b/quickstart/zilla.yaml
@@ -241,16 +241,13 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        -  ${{env.KAFKA_BOOTSTRAP_SERVER}}
     exit: south_kafka_tcp_client
   south_kafka_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: ${{env.KAFKA_HOST}}
-      port: ${{env.KAFKA_PORT}}
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0
 
 # Kafka to external gRPC server
   west_kafka_grpc_remote_server:

--- a/redpanda.broker/docker/compose/setup.sh
+++ b/redpanda.broker/docker/compose/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-redpanda-broker
+NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
 
 if [[ -z $(docker-compose -p $NAMESPACE ps -q redpanda) || -z $(docker-compose -p $NAMESPACE ps -q console) ]]; then
   docker-compose -p $NAMESPACE up -d

--- a/redpanda.broker/docker/compose/teardown.sh
+++ b/redpanda.broker/docker/compose/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-NAMESPACE=zilla-redpanda-broker
+NAMESPACE="${NAMESPACE:-zilla-redpanda-broker}"
 docker-compose -p $NAMESPACE down --remove-orphans

--- a/sse.kafka.fanout/setup.sh
+++ b/sse.kafka.fanout/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-sse-kafka-fanout
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-sse-kafka-fanout}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/sse.kafka.fanout/setup.sh
+++ b/sse.kafka.fanout/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-sse-kafka-fanout}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/sse.kafka.fanout/teardown.sh
+++ b/sse.kafka.fanout/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and Kafka
-NAMESPACE=zilla-sse-kafka-fanout
+NAMESPACE="${NAMESPACE:-zilla-sse-kafka-fanout}"
 helm uninstall zilla kafka --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/sse.kafka.fanout/zilla.yaml
+++ b/sse.kafka.fanout/zilla.yaml
@@ -103,13 +103,10 @@ bindings:
   south_kafka_client:
     type: kafka
     kind: client
+    options:
+      servers:
+        - kafka:29092
     exit: south_tcp_client
   south_tcp_client:
     type: tcp
     kind: client
-    options:
-      host: kafka
-      port: 29092
-    routes:
-      - when:
-          - cidr: 0.0.0.0/0

--- a/sse.proxy.jwt/setup.sh
+++ b/sse.proxy.jwt/setup.sh
@@ -5,8 +5,8 @@ set -ex
 docker image inspect zilla-examples/sse-server:latest --format 'Image Found {{.RepoTags}}'
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-sse-proxy-jwt
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-sse-proxy-jwt}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/sse.proxy.jwt/setup.sh
+++ b/sse.proxy.jwt/setup.sh
@@ -6,8 +6,9 @@ docker image inspect zilla-examples/sse-server:latest --format 'Image Found {{.R
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-sse-proxy-jwt}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/sse.proxy.jwt/teardown.sh
+++ b/sse.proxy.jwt/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla and SSE Server
-NAMESPACE=zilla-sse-proxy-jwt
+NAMESPACE="${NAMESPACE:-zilla-sse-proxy-jwt}"
 helm uninstall zilla sse-server --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/startup.sh
+++ b/startup.sh
@@ -12,7 +12,7 @@ COMPOSE_FOLDER="docker/compose"
 HELM_FOLDER="k8s/helm"
 USE_HELM=false
 USE_MAIN=false
-BOOTSTRAP_KAFKA=true
+INIT_KAFKA=true
 AUTO_TEARDOWN=false
 REMOTE_KAFKA=false
 KAFKA_BROKER="kafka"
@@ -22,7 +22,7 @@ WORKDIR=$(pwd)
 
 # help text
 read -r -d '' HELP_TEXT <<-EOF || :
-Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-bootstrap][--redpanda] example.name
+Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-kafka-init][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
@@ -36,7 +36,7 @@ Options:
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
     -v | --zilla-version  Sets the zilla version to use                                      [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
-         --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
+         --no-kafka-init  The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]
          --help           Print help                                                                         [boolean]
 
@@ -60,7 +60,7 @@ while [ "$1" != "$EOL" ]; do
     -v | --zilla-version ) check "$1" "$opt"; ZILLA_VERSION="$1"; shift;;
     -k | --use-helm      ) USE_HELM=true;;
     -m | --use-main      ) USE_MAIN=true;;
-         --no-bootstrap  ) BOOTSTRAP_KAFKA=false;;
+         --no-kafka-init ) INIT_KAFKA=false;;
          --auto-teardown ) AUTO_TEARDOWN=true;;
          --redpanda      ) KAFKA_BROKER="redpanda";;
          --help          ) printf "%s\n" "$USAGE"; exit 0;;
@@ -96,7 +96,7 @@ fi
 
 # don't start kafka if the example hasn't been reworked
 if [[ ! -d "$WORKDIR/$EXAMPLE_FOLDER/$HELM_FOLDER" && ! -d "$WORKDIR/$EXAMPLE_FOLDER/$COMPOSE_FOLDER" ]]; then
-    BOOTSTRAP_KAFKA=false
+    INIT_KAFKA=false
 fi
 
 
@@ -122,7 +122,7 @@ KAKFA_TEARDOWN_SCRIPT=""
 KAFKA_FOLDER="$KAFKA_BROKER.broker"
 if [[ $REMOTE_KAFKA == true ]]; then
     echo "Connecting to remote Kafka at $KAFKA_HOST:$KAFKA_PORT"
-elif [[ $BOOTSTRAP_KAFKA == true ]]; then
+elif [[ $INIT_KAFKA == true ]]; then
 
     if ! [[ -d "$WORKDIR/$KAFKA_FOLDER" ]]; then
         if [[ $USE_MAIN == true ]]; then
@@ -155,7 +155,7 @@ fi
 export ZILLA_VERSION=$ZILLA_VERSION
 export NAMESPACE="zilla-${EXAMPLE_FOLDER//./-}"
 export REMOTE_KAFKA=$REMOTE_KAFKA
-export BOOTSTRAP_KAFKA=$BOOTSTRAP_KAFKA
+export INIT_KAFKA=$INIT_KAFKA
 export KAFKA_BROKER=$KAFKA_BROKER
 export KAFKA_HOST=$KAFKA_HOST
 export KAFKA_PORT=$KAFKA_PORT

--- a/startup.sh
+++ b/startup.sh
@@ -11,7 +11,7 @@ COMPOSE_FOLDER="docker/compose"
 HELM_FOLDER="k8s/helm"
 USE_HELM=false
 USE_MAIN=false
-START_KAFKA=true
+BOOTSTRAP_KAFKA=true
 AUTO_TEARDOWN=false
 REMOTE_KAFKA=false
 KAFKA_BROKER="kafka"
@@ -21,7 +21,7 @@ WORKDIR=$(pwd)
 
 # help text
 read -r -d '' HELP_TEXT <<-EOF || :
-Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-kafka][--auto-teardown][--redpanda] example.name
+Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-bootstrap][--auto-teardown][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
@@ -34,7 +34,7 @@ Options:
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
     -v | --version        Sets the version to download                                       [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
-         --no-kafka       The script wont try to start a kafka broker                                        [boolean]
+         --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]
          --help           Print help                                                                         [boolean]
 
@@ -57,7 +57,7 @@ while [ "$1" != "$EOL" ]; do
     -v | --version       ) check "$1" "$opt"; VERSION="$1"; shift;;
     -k | --use-helm      ) USE_HELM=true;;
     -m | --use-main      ) USE_MAIN=true;;
-         --no-kafka      ) START_KAFKA=false;;
+         --no-bootstrap  ) BOOTSTRAP_KAFKA=false;;
          --auto-teardown ) AUTO_TEARDOWN=true;;
          --redpanda      ) KAFKA_BROKER="redpanda";;
          --help          ) printf "%s\n" "$USAGE"; exit 0;;
@@ -72,7 +72,8 @@ while [ "$1" != "$EOL" ]; do
 done; shift
 
 # pull the example folder from the end of the params and set defaults
-EXAMPLE_FOLDER="$*"
+operand=$*
+EXAMPLE_FOLDER=${operand//\//}
 [[ -z "$EXAMPLE_FOLDER" ]] && EXAMPLE_FOLDER="quickstart"
 [[ -z "$VERSION" ]] && VERSION=$(curl -s https://api.github.com/repos/$REPO/releases/latest | grep -i "tag_name" | awk -F '"' '{print $4}')
 [[ -z "$VERSION" ]] && USE_MAIN=true
@@ -92,7 +93,7 @@ fi
 
 # don't start kafka if the example hasn't been reworked
 if [[ ! -d "$WORKDIR/$EXAMPLE_FOLDER/$HELM_FOLDER" && ! -d "$WORKDIR/$EXAMPLE_FOLDER/$COMPOSE_FOLDER" ]]; then
-    START_KAFKA=false
+    BOOTSTRAP_KAFKA=false
 fi
 
 
@@ -118,7 +119,7 @@ KAKFA_TEARDOWN_SCRIPT=""
 KAFKA_FOLDER="$KAFKA_BROKER.broker"
 if [[ $REMOTE_KAFKA == true ]]; then
     echo "Connecting to remote Kafka at $KAFKA_HOST:$KAFKA_PORT"
-elif [[ $START_KAFKA == true ]]; then
+elif [[ $BOOTSTRAP_KAFKA == true ]]; then
 
     if ! [[ -d "$WORKDIR/$KAFKA_FOLDER" ]]; then
         if [[ $USE_MAIN == true ]]; then
@@ -130,26 +131,30 @@ elif [[ $START_KAFKA == true ]]; then
         fi
     fi
 
-    KAFKA_PORT=9092
+    export NAMESPACE="zilla-${KAFKA_FOLDER//./-}"
+    export KAFKA_PORT=9092
     if [[ $USE_HELM == true ]]; then
         cd "$WORKDIR"/"$KAFKA_FOLDER"/"$HELM_FOLDER"
-        KAFKA_HOST="kafka.zilla-kafka-broker.svc.cluster.local"
+        KAFKA_HOST="kafka.$NAMESPACE.svc.cluster.local"
     else
         cd "$WORKDIR"/"$KAFKA_FOLDER"/"$COMPOSE_FOLDER"
         KAFKA_HOST="host.docker.internal"
     fi
     chmod u+x teardown.sh
-    KAKFA_TEARDOWN_SCRIPT="$(pwd)/teardown.sh"
+    KAKFA_TEARDOWN_SCRIPT="NAMESPACE=$NAMESPACE $(pwd)/teardown.sh"
     printf "\n\n"
-    echo "==== Starting Kafka Use this script to teardown: $KAKFA_TEARDOWN_SCRIPT ===="
+    echo "==== Starting Kafka. Use this script to teardown ===="
+    printf '%s\n' "$KAKFA_TEARDOWN_SCRIPT"
     sh setup.sh
     echo "Kafka started at $KAFKA_HOST:$KAFKA_PORT"
 fi
+
+export NAMESPACE="zilla-${EXAMPLE_FOLDER//./-}"
+export REMOTE_KAFKA=$REMOTE_KAFKA
+export BOOTSTRAP_KAFKA=$BOOTSTRAP_KAFKA
 export KAFKA_BROKER=$KAFKA_BROKER
-if [[ $REMOTE_KAFKA == true || $START_KAFKA == true ]]; then
-    export KAFKA_HOST=$KAFKA_HOST
-    export KAFKA_PORT=$KAFKA_PORT
-fi
+export KAFKA_HOST=$KAFKA_HOST
+export KAFKA_PORT=$KAFKA_PORT
 
 TEARDOWN_SCRIPT=""
 if [[ $USE_HELM == false && -d "$WORKDIR/$EXAMPLE_FOLDER/$COMPOSE_FOLDER" ]]; then
@@ -164,9 +169,10 @@ if [[ $USE_HELM == false && -d "$WORKDIR/$EXAMPLE_FOLDER/$COMPOSE_FOLDER" ]]; th
 
     cd "$WORKDIR"/"$EXAMPLE_FOLDER"/"$COMPOSE_FOLDER"
     chmod u+x teardown.sh
-    TEARDOWN_SCRIPT="$(pwd)/teardown.sh"
+    TEARDOWN_SCRIPT="NAMESPACE=$NAMESPACE $(pwd)/teardown.sh"
     printf "\n\n"
-    echo "==== Starting Zilla $EXAMPLE_FOLDER with Compose. Use this script to teardown: $(pwd)/teardown.sh ===="
+    echo "==== Starting Zilla $EXAMPLE_FOLDER with Compose. Use this script to teardown ===="
+    printf '%s\n' "$TEARDOWN_SCRIPT"
     sh setup.sh
 fi
 
@@ -187,9 +193,10 @@ if [[ $USE_HELM == true ]]; then
     fi
 
     chmod u+x teardown.sh
-    TEARDOWN_SCRIPT="$(pwd)/teardown.sh"
+    TEARDOWN_SCRIPT="NAMESPACE=$NAMESPACE $(pwd)/teardown.sh"
     printf "\n\n"
-    echo "==== Starting Zilla $EXAMPLE_FOLDER with Helm. Use this script to teardown: $(pwd)/teardown.sh ===="
+    echo "==== Starting Zilla $EXAMPLE_FOLDER with Helm. Use this script to teardown ===="
+    printf '%s\n' "$TEARDOWN_SCRIPT"
     sh setup.sh
 fi
 
@@ -217,7 +224,7 @@ if [[ $AUTO_TEARDOWN == true ]]; then
     printf "\n\n"
     echo "==== Auto teardown ===="
     printf '%s\n' "$TEARDOWN_SCRIPT" "$KAKFA_TEARDOWN_SCRIPT"
-    [[ -n "$TEARDOWN_SCRIPT" ]] && $TEARDOWN_SCRIPT
-    [[ -n "$KAKFA_TEARDOWN_SCRIPT" ]] && $KAKFA_TEARDOWN_SCRIPT
+    [[ -n "$TEARDOWN_SCRIPT" ]] && bash -c "$TEARDOWN_SCRIPT"
+    [[ -n "$KAKFA_TEARDOWN_SCRIPT" ]] && bash -c "$KAKFA_TEARDOWN_SCRIPT"
 fi
 printf "\n"

--- a/startup.sh
+++ b/startup.sh
@@ -5,6 +5,7 @@ REPO=aklivity/zilla-examples
 RELEASE_URL="https://github.com/$REPO/releases/download"
 MAIN_URL="https://api.github.com/repos/$REPO/tarball"
 VERSION=""
+ZILLA_VERSION=""
 EXAMPLE_FOLDER=""
 KAFKA_FOLDER=""
 COMPOSE_FOLDER="docker/compose"
@@ -21,18 +22,19 @@ WORKDIR=$(pwd)
 
 # help text
 read -r -d '' HELP_TEXT <<-EOF || :
-Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v VERSION][--no-bootstrap][--auto-teardown][--redpanda] example.name
+Usage: ${CMD:=${0##*/}} [-km][-h KAFKA_HOST -p KAFKA_PORT][-d WORKDIR][-v ZILLA_VERSION][-e EX_VERSION][--no-bootstrap][--redpanda] example.name
 
 Operand:
     example.name          The name of the example to use                                 [default: quickstart][string]
 
 Options:
+    -e | --ex-version     Sets the examples version to download                              [default: latest][string]
     -d | --workdir        Sets the directory used to download and run the example                             [string]
     -h | --kafka-host     Sets the hostname used when connecting to Kafka                                     [string]
     -k | --use-helm       Use the helm install, if available, instead of compose                             [boolean]
     -m | --use-main       Download the head of the main branch                                               [boolean]
     -p | --kafka-port     Sets the port used when connecting to Kafka                                         [string]
-    -v | --version        Sets the version to download                                       [default: latest][string]
+    -v | --zilla-version  Sets the zilla version to use                                      [default: latest][string]
          --auto-teardown  Executes the teardown script immediately after setup                               [boolean]
          --no-bootstrap   The script wont try to bootstrap the kafka broker                                  [boolean]
          --redpanda       Makes the included kafka broker and scripts use Redpanda                           [boolean]
@@ -51,10 +53,11 @@ while [ "$1" != "$EOL" ]; do
   case "$opt" in
 
     #defined options
+    -e | --ex-version    ) check "$1" "$opt"; VERSION="$1"; shift;;
     -h | --kafka-host    ) check "$1" "$opt"; KAFKA_HOST="$1"; REMOTE_KAFKA=true; shift;;
     -p | --kafka-port    ) check "$1" "$opt"; KAFKA_PORT="$1"; shift;;
     -d | --workdir       ) check "$1" "$opt"; WORKDIR="$1"; shift;;
-    -v | --version       ) check "$1" "$opt"; VERSION="$1"; shift;;
+    -v | --zilla-version ) check "$1" "$opt"; ZILLA_VERSION="$1"; shift;;
     -k | --use-helm      ) USE_HELM=true;;
     -m | --use-main      ) USE_MAIN=true;;
          --no-bootstrap  ) BOOTSTRAP_KAFKA=false;;
@@ -149,6 +152,7 @@ elif [[ $BOOTSTRAP_KAFKA == true ]]; then
     echo "Kafka started at $KAFKA_HOST:$KAFKA_PORT"
 fi
 
+export ZILLA_VERSION=$ZILLA_VERSION
 export NAMESPACE="zilla-${EXAMPLE_FOLDER//./-}"
 export REMOTE_KAFKA=$REMOTE_KAFKA
 export BOOTSTRAP_KAFKA=$BOOTSTRAP_KAFKA

--- a/tcp.echo/setup.sh
+++ b/tcp.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-tcp-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml
 

--- a/tcp.echo/setup.sh
+++ b/tcp.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-tcp-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-tcp-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml

--- a/tcp.echo/teardown.sh
+++ b/tcp.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-tcp-echo
+NAMESPACE="${NAMESPACE:-zilla-tcp-echo}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/tcp.reflect/setup.sh
+++ b/tcp.reflect/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-tcp-reflect
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-tcp-reflect}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml

--- a/tcp.reflect/setup.sh
+++ b/tcp.reflect/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-tcp-reflect}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml
 

--- a/tcp.reflect/teardown.sh
+++ b/tcp.reflect/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-tcp-reflect
+NAMESPACE="${NAMESPACE:-zilla-tcp-reflect}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/tls.echo/setup.sh
+++ b/tls.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-tls-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/tls.echo/setup.sh
+++ b/tls.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-tls-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-tls-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/tls.echo/teardown.sh
+++ b/tls.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-tls-echo
+NAMESPACE="${NAMESPACE:-zilla-tls-echo}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/tls.reflect/setup.sh
+++ b/tls.reflect/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-tls-reflect
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-tls-reflect}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/tls.reflect/setup.sh
+++ b/tls.reflect/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-tls-reflect}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/tls.reflect/teardown.sh
+++ b/tls.reflect/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-tls-reflect
+NAMESPACE="${NAMESPACE:-zilla-tls-reflect}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/ws.echo/setup.sh
+++ b/ws.echo/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-ws-echo
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-ws-echo}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/ws.echo/setup.sh
+++ b/ws.echo/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-ws-echo}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/ws.echo/teardown.sh
+++ b/ws.echo/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-ws-echo
+NAMESPACE="${NAMESPACE:-zilla-ws-echo}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE

--- a/ws.reflect/setup.sh
+++ b/ws.reflect/setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
-ZILLA_CHART=oci://ghcr.io/aklivity/charts/zilla
-NAMESPACE=zilla-ws-reflect
+ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+NAMESPACE="${NAMESPACE:-zilla-ws-reflect}"
 helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \

--- a/ws.reflect/setup.sh
+++ b/ws.reflect/setup.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Install Zilla to the Kubernetes cluster with helm and wait for the pod to start up
 ZILLA_CHART="${ZILLA_CHART:-oci://ghcr.io/aklivity/charts/zilla}"
+ZILLA_VERSION="${ZILLA_VERSION:-^0.9.0}"
 NAMESPACE="${NAMESPACE:-zilla-ws-reflect}"
-helm upgrade --install zilla $ZILLA_CHART --namespace $NAMESPACE --create-namespace --wait \
+helm upgrade --install zilla $ZILLA_CHART --version $ZILLA_VERSION --namespace $NAMESPACE --create-namespace --wait \
     --values values.yaml \
     --set-file zilla\\.yaml=zilla.yaml \
     --set-file secrets.tls.data.localhost\\.p12=tls/localhost.p12

--- a/ws.reflect/teardown.sh
+++ b/ws.reflect/teardown.sh
@@ -5,6 +5,6 @@ set -x
 pgrep kubectl && killall kubectl
 
 # Uninstall Zilla engine
-NAMESPACE=zilla-ws-reflect
+NAMESPACE="${NAMESPACE:-zilla-ws-reflect}"
 helm uninstall zilla --namespace $NAMESPACE
 kubectl delete namespace $NAMESPACE


### PR DESCRIPTION
This PR 

- Adds Parameter expansion to the defined variables in the example scripts. 
- Replaces the `no-kafka` options with a `no-kafka-init` option to control when extra Kafka config is applied
- Replaces the `kafka-host` and `kafka-port` options with a `-k | --kafka-server` option to set the `KAFKA_BOOTSTRAP_SERVER` var 
- Parameterize the Zilla version to aid in testing/running in case of bugs. Helm charts will get the most recent patch release with `^0.9.0` and compose files will point to the `latest` image tag.