### PR TITLE
refactor startup.sh script to use `docker compose` command

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -106,12 +106,13 @@ export EXAMPLE_DIR="$WORKDIR/$EXAMPLE_FOLDER"
 TEARDOWN_SCRIPT=""
 cd "$WORKDIR"/"$EXAMPLE_FOLDER"
 
-chmod u+x teardown.sh
-TEARDOWN_SCRIPT="$(pwd)/teardown.sh"
+TEARDOWN_SCRIPT="docker compose -f $WORKDIR/$EXAMPLE_FOLDER/compose.yaml down"
 printf "\n\n"
 echo "==== Starting Zilla $EXAMPLE_FOLDER. Use this script to teardown ===="
 printf '%s\n' "$TEARDOWN_SCRIPT"
-sh setup.sh
+printf "\n\n"
+
+docker compose -f "$WORKDIR"/"$EXAMPLE_FOLDER/compose.yaml" up -d
 
 printf "\n\n"
 echo "==== Check out the README to see how to use this example ==== "


### PR DESCRIPTION
This change will allow the startup script to start and stop an example using the startup.sh from inside the repo or as part of the `wget` based run command.